### PR TITLE
Define latencies below 150 ms as near real-time latencies.

### DIFF
--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -553,7 +553,7 @@ Streaming media latency refers to the "glass-to-glass" time duration, which is t
 
 Streaming media can be usefully categorized according to the application's latency requirements into a few rough categories:
 
-- near realtime latency (less than 150 milliseconds)
+- near realtime latency (less than 200 milliseconds)
 - ultra low-latency     (less than 1 second)
 - low-latency live      (less than 10 seconds)
 - non-low-latency live  (10 seconds to a few minutes)
@@ -561,12 +561,16 @@ Streaming media can be usefully categorized according to the application's laten
 
 ## Near Realtime Latency
 
-Near realtime delivery of media is defined here as having a glass-to-glass (or ear-to-ear) delay target under 150 milliseconds.
-The human ear or eye would mostly not notice or would be on the edge of noticing such latencies.
-These latencies are targeted in various telepresence use cases, such as remote control of drones and autonomous vehicles (e.g. teledriving), remote surgery. For musicians to play together in sync the ideal delay would be below 50 ms.
-In cloud gaming delay around 150 ms is at the edge of comfortable experience. Higher delays make the game unplayable. Tatget delay is 50 ms. The lower detectable limit is 13 ms.
+Some internet applications that incorporate media streaming have specific interactivity or
+control-feedback requirements that drive much lower glass to glass media latency targets
+than one second. These include videoconferencing or voice calls, remote video game play,
+remote control of hardware platforms like drones, vehicles, or surgical robots, and many
+other envisioned or deployed interactive applications.
 
-Another example of latency-sensitive use case is stock exchange market trading (not an algo-trading), where the earlier some live event is being received, the earlier the trading decision can be made.
+Applications with latency targets in these regimes are out of scope for this document,
+as those use cases technically are not exactly technically "streaming video".
+However, to acknowledge these use cases exist, and to provide a name for such latencies,
+this document defines glass-to-glass (or ear-to-ear) latencies below 150 ms as near realtime latencies.
 
 ## Ultra Low-Latency {#ultralow}
 

--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -527,7 +527,8 @@ The causes of unpredictable usage described in {{sec-unpredict}} were more or le
 In his talk, Sanjay Mishra {{Mishra}} reported that after the CoViD-19 pandemic broke out in early 2020,
 
 - Comcast's streaming and web video consumption rose by 38%, with their reported peak traffic up 32% overall between March 1 to March 30,
-- AT&T reported a 28% jump in core network traffic (single day in April, as compared to pre stay-at-home daily average traffic), with video accounting for nearly half of all mobile network traffic, while
+- AT&T reported a 28% jump in core network traffic (single day in April, as compared to pre stay-at-home daily average traffic), with video accounting for 
+ly half of all mobile network traffic, while
 social networking and web browsing remained the highest percentage (almost a quarter each) of overall mobility traffic, and
 - Verizon reported similar trends with video traffic up 36% over an average day (pre COVID-19)}.
 
@@ -570,7 +571,7 @@ other envisioned or deployed interactive applications.
 Applications with latency targets in these regimes are out of scope for this document,
 as those use cases technically are not exactly technically "streaming video".
 However, to acknowledge these use cases exist, and to provide a name for such latencies,
-this document defines glass-to-glass (or ear-to-ear) latencies below 150 ms as near realtime latencies.
+this document defines glass-to-glass (or ear-to-ear) latencies below 200 ms as near realtime latencies.
 
 ## Ultra Low-Latency {#ultralow}
 

--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -553,10 +553,20 @@ Streaming media latency refers to the "glass-to-glass" time duration, which is t
 
 Streaming media can be usefully categorized according to the application's latency requirements into a few rough categories:
 
-- ultra low-latency    (less than 1 second)
-- low-latency live     (less than 10 seconds)
-- non-low-latency live (10 seconds to a few minutes)
-- on-demand            (hours or more)
+- near realtime latency (less than 150 milliseconds)
+- ultra low-latency     (less than 1 second)
+- low-latency live      (less than 10 seconds)
+- non-low-latency live  (10 seconds to a few minutes)
+- on-demand             (hours or more)
+
+## Near Realtime Latency
+
+Near realtime delivery of media is defined here as having a glass-to-glass (or ear-to-ear) delay target under 150 milliseconds.
+The human ear or eye would mostly not notice or would be on the edge of noticing such latencies.
+These latencies are targeted in various telepresence use cases, such as remote control of drones and autonomous vehicles (e.g. teledriving), remote surgery. For musicians to play together in sync the ideal delay would be below 50 ms.
+In cloud gaming delay around 150 ms is at the edge of comfortable experience. Higher delays make the game unplayable. Tatget delay is 50 ms. The lower detectable limit is 13 ms.
+
+Another example of latency-sensitive use case is stock exchange market trading (not an algo-trading), where the earlier some live event is being received, the earlier the trading decision can be made.
 
 ## Ultra Low-Latency {#ultralow}
 

--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -527,8 +527,7 @@ The causes of unpredictable usage described in {{sec-unpredict}} were more or le
 In his talk, Sanjay Mishra {{Mishra}} reported that after the CoViD-19 pandemic broke out in early 2020,
 
 - Comcast's streaming and web video consumption rose by 38%, with their reported peak traffic up 32% overall between March 1 to March 30,
-- AT&T reported a 28% jump in core network traffic (single day in April, as compared to pre stay-at-home daily average traffic), with video accounting for 
-ly half of all mobile network traffic, while
+- AT&T reported a 28% jump in core network traffic (single day in April, as compared to pre stay-at-home daily average traffic), with video accounting for nearly half of all mobile network traffic, while
 social networking and web browsing remained the highest percentage (almost a quarter each) of overall mobility traffic, and
 - Verizon reported similar trends with video traffic up 36% over an average day (pre COVID-19)}.
 


### PR DESCRIPTION
I propose defining latencies less than 150 ms as near real-time latencies.

These latencies can be used by musicians to play together in sync. And I guess the human ear or eye would mostly not notice any delay below 50 ms.
Might be worth doing a bit of research around the topic to refine the ranges though.
For instance, in this paper (https://ieeexplore.ieee.org/document/5540888) they conclude:
> ... the visual response latency ranges from 74ms to 106ms...

In another source (https://www.pubnub.com/blog/how-fast-is-realtime-human-perception-and-technology/) the following is defined:
> 300ms < game is unplayable
    150ms  < game play degraded 
    100ms < player performance affected
    50ms   > target performance
    13ms    > lower detectable limit

< 200 ms - comfortable latencies for conversation.

**_Note._** Migrated from https://github.com/fiestajetsam/draft-gruessing-moq-requirements/pull/64

_(Sorry for proposing this close to the last call)._