### PR TITLE
Explain scope of tunneling in this draft

### DIFF
--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -282,6 +282,11 @@ informative:
     date: 3 July, 2020
     seriesinfo:  "IEEE Communications Surveys & Tutorials"
 
+  ISOBMFF:
+    target: https://www.iso.org/standard/83102.html
+    title: "ISO/IEC 14496-12:2022 Information technology — Coding of audio-visual objects — Part 12: ISO base media file format"
+    date:  January 2022
+
   I-D.ietf-quic-http:
   I-D.ietf-quic-manageability:
   I-D.ietf-quic-datagram:
@@ -294,6 +299,7 @@ informative:
 
   RFC0793:
   RFC2001:
+  RFC2736:
   RFC3135:
   RFC3550:
   RFC3758:
@@ -750,6 +756,32 @@ As noted in {{sec-abr}}, ABR response strategies such as HLS {{RFC8216}} or DASH
 For most of the history of the Internet, these transport protocols, described in {{udp-behavior}} and {{tcp-behavior}}, have had relatively consistent behaviors that have changed slowly, if at all, over time. Newly standardized transport protocols like QUIC {{RFC9000}} can behave differently from existing transport protocols, and these behaviors may evolve over time more rapidly than currently-used transport protocols.
 
 For this reason, we have included a description of how the path characteristics that streaming media providers may see are likely to evolve over time.
+
+## Transport Protocols and Media Transport Protocols {#mtp}
+
+Within {{sec-trans}}, the term "Media Transport Protocol" is used to describe to describe the protocol of interest. This is easier to understand if the reader assumes a protocol stack that looks something like this:
+
+~~~~
+               Media
+    ---------------------------
+           Media Format
+    ---------------------------
+    Media Transport Protocol(s)
+    ---------------------------
+      Transport Protocol(s)
+~~~~
+
+where
+
+* "Media Format" would be something like an RTP payload format {{RFC2736}} or ISOBMFF {{ISOBMFF}},
+* "Media Transport Protocol" would be something like RTP or HTTP, and
+* "Transport Protocol" would be something like TCP or UDP.
+
+Not all possible streaming media applications follow this model, but for the ones that do, it seems useful to have names for "the protocol layers beteern Media and the Transport Layer".
+
+It is worth noting explicitly that the "Media Transport Protocol" layer might include more than one protocol. For example, a Media Transport Protocol might be defined to run over HTTP, or over WebTransport, over HTTP/3.
+
+It is worth noting explicitly that more complex network protocol stacks are certainly possible - for instance, packets with this protocol stack may be carried in a tunnel, or in a VPN. If these environments are present, streaming media operators may need to analyze their effects on applications as well.
 
 ## UDP and Its Behavior {#udp-behavior}
 

--- a/draft-ietf-mops-streaming-opcons.md
+++ b/draft-ietf-mops-streaming-opcons.md
@@ -575,7 +575,7 @@ Some media content providers aim to achieve this level of latency for live media
 
 Applications requiring ultra low latency for media delivery are usually tightly constrained on the available choices for media transport technologies, and sometimes may need to operate in controlled environments to reliably achieve their latency and quality goals.
 
-Most applications operating over IP networks and requiring latency this low use the Real-time Transport Protocol (RTP) {{RFC3550}} or WebRTC {{RFC8825}}, which uses RTP for the media transport as well as several other protocols necessary for safe operation in browsers.
+Most applications operating over IP networks and requiring latency this low use the Real-time Transport Protocol (RTP) {{RFC3550}} or WebRTC {{RFC8825}}, which uses RTP as its Media Transport Protocol, along with several other protocols necessary for safe operation in browsers.
 
 Worth noting is that many applications for ultra low-latency delivery do not need to scale to more than a few users at a time, which simplifies many delivery considerations relative to other use cases.
 
@@ -777,9 +777,9 @@ where
 * "Media Transport Protocol" would be something like RTP or HTTP, and
 * "Transport Protocol" would be something like TCP or UDP.
 
-Not all possible streaming media applications follow this model, but for the ones that do, it seems useful to have names for "the protocol layers beteern Media and the Transport Layer".
+Not all possible streaming media applications follow this model, but for the ones that do, it seems useful to have names for the protocol layers between Media Format and Transport Layer
 
-It is worth noting explicitly that the "Media Transport Protocol" layer might include more than one protocol. For example, a Media Transport Protocol might be defined to run over HTTP, or over WebTransport, over HTTP/3.
+It is worth noting explicitly that the Media Transport Protocol and Transport Protocol layers might each include more than one protocol. For example, a Media Transport Protocol might run over HTTP, or over WebTransport, which in turn runs over HTTP.
 
 It is worth noting explicitly that more complex network protocol stacks are certainly possible - for instance, packets with this protocol stack may be carried in a tunnel, or in a VPN. If these environments are present, streaming media operators may need to analyze their effects on applications as well.
 


### PR DESCRIPTION
closes #144 

@GrumpyOldTroll - several things here. 

* we probably don't need all of the descriptive text - the idea is that we'd say "assume roughly this protocol stack, and here's what's not included"
* if distinguishing between "transport protocol" and "media transport protocol" makes sense, that probably needs to be reflected elsewhere in the document (like, a lot of elsewheres)
* If this approach works, it could either be in the transport protocol section, or in the one you're thinking of for #159 